### PR TITLE
Add decisions section to onboarding docs.

### DIFF
--- a/backend-dev/Decisions.md
+++ b/backend-dev/Decisions.md
@@ -18,7 +18,7 @@ Without this data, the goal of becoming a viable resource for those in need will
 
 ### Do we need a server at all?
 
-Undecided at this time.
+We have yet to identify any true need for a server at the time of launch.  All scrapers can be launched manually and from the developers local machine.
 
 ### Should we get consent from the businesses we list prior to listing them?
 

--- a/backend-dev/Decisions.md
+++ b/backend-dev/Decisions.md
@@ -1,0 +1,32 @@
+# Decisions
+
+All questions and concerns that have come up will be documented here along with their answers.
+
+### What, if anything, should we do to safeguard the public-facing data on this site?
+
+The data on this site was public to begin with.  Scraped from other public sites, or given to us to use publicly with consent.
+Therefore, no actions to safeguard the company data on this site need to be taken.
+This includes not needing to safelist/blocklist IP addresses with technology such as cloudflare.
+
+We should, of course, be up front about data privacy and take all necessary precautions with any private information we may have.
+
+### Why are we scraping data from public sites?
+
+We are scraping data from public sites in order to jump-start this project with an initial set of data large enough to be useful to the visitors of the site.
+
+Without this data, the goal of becoming a viable resource for those in need will be considerably more difficult to achieve.
+
+### Do we need a server at all?
+
+Undecided at this time.
+
+### Should we get consent from the businesses we list prior to listing them?
+
+We've determined that consent is not required in the case where we are scraping publicly-available information from publicly-available websites.
+
+We will, however, offer an option for a business to remove themselves from the site.
+
+### How often will the scrapers run?
+
+Initially just once at the beginning to seed the site with data.  We are unsure how frequently they will run after 
+the initial launch, but right now we're thinking they will run monthly.

--- a/backend-dev/Overview.md
+++ b/backend-dev/Overview.md
@@ -26,3 +26,7 @@ Back-end developer responsibilites within the org include the following:
 Tasks will be added to Trello. Anything in the "Intake" column is fair game. If you see a task that you are willing to tackle, please assign it to yourself, and include a comment tagging the Team Lead / Project Manager. This comment should include a _rough_ estimate of when you anticipate completing the task. As a volunteer organization we want to make sure that tasks do not sit idle for long.
 
 If you need help with a task, or have encountered a task that is more complicated than you expected, please don't hesitate to reach out to any of the points of contact above and we will advise on how to best get that task finished! Overcommunication is key so we can work quickly in these chaotic times.
+
+## Decisions
+
+All decisions that have been made are captured in the [decision log](./Decisions.md).  Please check there for questions that have already been raised an answered.


### PR DESCRIPTION
Great discussions unfolded today that lead to several key decisions being made.  It's important for everyone to have access to these questions and their outcomes, but it's difficult to piece them together across the various conversations.  So, I added them to the onboarding docs for convenience.